### PR TITLE
VMware Refactor and new template

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ The automation requires an HTTP or NFS server to hold the ICP binaries and docke
 
    ##### ICP installation method #####
    icp_inception_image = "ibmcom/icp-inception:3.1.0-ee"
-   private_registry    = "registry.cred.lab.cloudns.cx"
+   private_registry    = "registry.example.com"
    registry_username   = "myUsername"
    registry_password   = "myPassword"
 
@@ -173,7 +173,7 @@ image_location = "nfs:<nfs_server_ip_address>:<path_within_your_nfs_server>/ibm-
 ```
 ##### ICP installation method #####
 icp_inception_image = "ibmcom/icp-inception:3.1.0-ee"
-private_registry    = "registry.lab.cloudns.cx"
+private_registry    = "registry.example.com"
 ```
 
 1. Install from a private Docker registry which requires authentication. In order to install ICP from a previously configured (with ICP images loaded into) private Docker registry which requires authentication, we need to specify the `private_registry` and its credentials, `registry_username` and `registry_password`, in the `terraform.tfvars` file:
@@ -181,7 +181,7 @@ private_registry    = "registry.lab.cloudns.cx"
 ```
 ##### ICP installation method #####
 icp_inception_image = "ibmcom/icp-inception:3.1.0-ee"
-private_registry    = "registry.cred.lab.cloudns.cx"
+private_registry    = "registry.example.com"
 registry_username   = "myUsername"
 registry_password   = "myPassword"
 ```

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This Terraform example configurations uses the [VMware vSphere provider](https://www.terraform.io/docs/providers/vsphere/index.html) to provision virtual machines on VMware
 and [TerraForm Module ICP Deploy](https://github.com/ibm-cloud-architecture/terraform-module-icp-deploy) to prepare VMs and deploy [IBM Cloud Private](https://www.ibm.com/cloud-computing/products/ibm-cloud-private/) on them.  This Terraform template automates best practices learned from installing ICP on VMware at numerous client sites in production.
 
-This template provisions an HA cluster with ICP 2.1.0.3 enterprise edition.
+This template provisions an HA cluster with ICP 3.1 enterprise edition.
 
 ![](./static/icp_ha_vmware.png)
 
@@ -17,7 +17,7 @@ This template provisions an HA cluster with ICP 2.1.0.3 enterprise edition.
 ### VM Template image preparation
 
 1. Create a VM image (RHEL or Ubuntu 16.04).
-   * the automation will create an additional block device at unit number 1 (i.e. `/dev/sdb`) for local docker container images  and attempt to configure Docker in [direct-lvm](https://docs.docker.com/storage/storagedriver/device-mapper-driver/#configure-loop-lvm-mode-for-testing) mode.  Additional block devices are also mounted at various directories that hold ICP data depending on the node role. You may pre-install docker, but it must be configured in direct-lvm mode, with the direct-lvm block device as the second disk. The simplest way of getting this to work is to create a template with a single OS disk without installing docker and let the automation configure direct-lvm mode.
+   * The automation will create an additional block device at unit number 1 (i.e. `/dev/sdb`) for local docker container images and attempt to configure Docker in direct-lvm or overlay2 mode, depending on your operating system. RHEL 7.4 and older will default to devicemapper, RHEL 7.5 and newer will default to Overlay2. All supported Ubuntu versions will default to Overlay2. Additional block devices are also mounted at various directories that hold ICP data depending on the node role. You may pre-install docker, but it must be configured in direct-lvm or overlay2 mode. For direct-lvm the block device must be set as the second disk. The simplest way of getting this to work is to create a template with a single OS disk without installing docker and let the automation configure direct-lvm or overlay2 mode as appropriate.
 
 1. Ensure that the `ssh_user` can call `sudo` without password.
 
@@ -36,7 +36,7 @@ This template provisions an HA cluster with ICP 2.1.0.3 enterprise edition.
 1. (optional) If you are not providing `image_location`, and have pre-installed docker, you can also pre-load the docker images from the ICP package you wish to install.
 
    ```bash
-   tar xf ibm-cloud-private-x86_64-2.1.0.3.tar.gz -O | sudo docker load
+   tar xf ibm-cloud-private-x86_64-3.1.tar.gz -O | sudo docker load
    ```
 
 1. Shutdown the VM Convert to a template, make note the name of the template.
@@ -50,9 +50,9 @@ The automation requires an HTTP or NFS server to hold the ICP binaries and docke
 1. git clone or download the templates
 
 1. Export your vSphere username and password into environment variables on the system you will run Terraform from.  This can be done via the following commands:
-  - `export VSPHERE_USER={myusername}` replacing `{myusername}` with your vSphere username
-  - `export VSPHERE_PASSWORD={mypassword}` replacing `{mypassword}` with your vSphere password
-  
+    - `export VSPHERE_USER={myusername}` replacing `{myusername}` with your vSphere username
+    - `export VSPHERE_PASSWORD={mypassword}` replacing `{mypassword}` with your vSphere password
+
 1. Create a `terraform.tfvars` file to reflect your environment.  Please see [variables.tf](variables.tf) and below tables for variable names and descriptions.  Here is an example `terraform.tfvars` file:
 
    ```
@@ -60,21 +60,21 @@ The automation requires an HTTP or NFS server to hold the ICP binaries and docke
    ##### vSphere Access Credentials ######
    #######################################
    vsphere_server = "10.25.0.20"
-   
+
    # Set username/password as environment variables VSPHERE_USER and VSPHERE_PASSWORD
-   
+
    ##############################################
    ##### vSphere deployment specifications ######
    ##############################################
    # Following resources must exist in vSphere
    vsphere_datacenter = "DC1"
    vsphere_cluster = "Cluster1"
-   vsphere_resource_pool = "ICP2013_pool/terraform_icp_2103"
+   vsphere_resource_pool = "ICP31_pool/terraform_icp_31"
    network_label = "LabPrivate"
    datastore = "LabDatastore"
    template = "ubuntu_1604_base_template"
    # Folder to provision the new VMs in, does not need to exist in vSphere
-   folder = "terraform_icp_2103"
+   folder = "terraform_icp_31"
 
    ##################################
    ##### ICP deployment details #####
@@ -82,7 +82,7 @@ The automation requires an HTTP or NFS server to hold the ICP binaries and docke
 
    ##### ICP instance name #####
    # MUST consist of only lower case alphanumeric characters and '-'
-   instance_name = "user1-icp-2103"
+   instance_name = "user1-icp-31"
 
 
    ##### Network #####
@@ -102,8 +102,11 @@ The automation requires an HTTP or NFS server to hold the ICP binaries and docke
    ssh_user = "virtuser"
    ssh_password = "SuperPa88w0rd"
 
-   ##### ICP installer image #####
-   icp_inception_image = "registry.lab.cloudns.cx/ibmcom/icp-inception:2.1.0.3-ee"
+   ##### ICP installation method #####
+   icp_inception_image = "ibmcom/icp-inception:3.1.0-ee"
+   private_registry    = "registry.cred.lab.cloudns.cx"
+   registry_username   = "myUsername"
+   registry_password   = "myPassword"
 
    ##### ICP admin user password #####
    # Non default admin user password 'admin' recommended
@@ -143,12 +146,8 @@ The automation requires an HTTP or NFS server to hold the ICP binaries and docke
    }
 
    ##### NFS Server #####
-   registry_mount_src = "10.0.0.5:/storage/user1-icp-2103/registry"
-   audit_mount_src = "10.0.0.5:/storage/user1-icp-2103/audit"
-
-   ##### ICP Management Services #####
-   disable_istio = "true"
-   disable_custom_metrics_adapter = "false"
+   registry_mount_src = "10.0.0.5:/storage/user1-icp-31/registry"
+   audit_mount_src = "10.0.0.5:/storage/user1-icp-31/audit"
    ```
 
 1. Run `terraform init` to download dependencies (modules and plugins)
@@ -156,6 +155,36 @@ The automation requires an HTTP or NFS server to hold the ICP binaries and docke
 1. Run `terraform plan` to investigate deployment plan
 
 1. Run `terraform apply` to start deployment
+
+### ICP installation method
+
+Below you can find the different paths to install ICP on VMware.
+
+1. Install from ICP binary package. In order to install ICP from it's binary package, we need to specify the `image_location` of the binary in the `terraform.tfvars` file:
+
+```
+##### ICP installation method #####
+icp_inception_image = "ibmcom/icp-inception:3.1.0-ee"
+image_location = "nfs:<nfs_server_ip_address>:<path_within_your_nfs_server>/ibm-cloud-private-x86_64-3.1.0.tar.gz"
+```
+
+1. Install from a private Docker registry which does not require authentication. In order to install ICP from a previously configured (with ICP images loaded into) private Docker registry which does not require authentication, we need to specify the `private_registry` in the `terraform.tfvars` file:
+
+```
+##### ICP installation method #####
+icp_inception_image = "ibmcom/icp-inception:3.1.0-ee"
+private_registry    = "registry.lab.cloudns.cx"
+```
+
+1. Install from a private Docker registry which requires authentication. In order to install ICP from a previously configured (with ICP images loaded into) private Docker registry which requires authentication, we need to specify the `private_registry` and its credentials, `registry_username` and `registry_password`, in the `terraform.tfvars` file:
+
+```
+##### ICP installation method #####
+icp_inception_image = "ibmcom/icp-inception:3.1.0-ee"
+private_registry    = "registry.cred.lab.cloudns.cx"
+registry_username   = "myUsername"
+registry_password   = "myPassword"
+```
 
 ### Terraform configuration
 
@@ -199,9 +228,12 @@ The automation requires an HTTP or NFS server to hold the ICP binaries and docke
 |----------------|------------|--------------|
 | `ssh_user` | `root` | User that terraform will SSH as, must have passwordless sudo access. |
 | `ssh_password` | &lt;none&gt; | Password for SSH user, needed to SSH in machines and add the Terraform-created SSH keys for password-less SSH installation |
-| `docker_package_location` | &lt;none&gt; | location of ICP docker package,  e.g. `http://<myhost>/icp-docker-17.09_x86_64.bin` or `nfs:<myhost>:/path/to/icp-docker-17.09_x86_64.bin` |
-| `image_location` | &lt;none&gt; | location of ICP binary package,  e.g. `http://<myhost>/ibm-cloud-private-x86_64-2.1.0.2.tar.gz` or `nfs:<myhost>:/path/to/ibm-cloud-private-x86_64-2.1.0.2.tar.gz` |
-| `icp_inception_image` | `ibmcom/icp-inception:2.1.0.2-ee` | Name of the `icp-inception` image to use.  You may need to change it to install a different version of ICP. |
+| `docker_package_location` | &lt;none&gt; | location of ICP docker package,  e.g. `http://<myhost>/icp-docker-18.03_x86_64.bin` or `nfs:<myhost>:/path/to/icp-docker-18.03_x86_64.bin` |
+| `icp_inception_image` | `ibmcom/icp-inception:3.1.0-ee` | Name of the `icp-inception` image to use.  You may need to change it to install a different version of ICP. |
+| `image_location` | &lt;none&gt; | location of ICP binary package,  e.g. `http://<myhost>/ibm-cloud-private-x86_64-3.1.0.tar.gz` or `nfs:<myhost>:/path/to/ibm-cloud-private-x86_64-3.1.0.tar.gz` |
+| `private_registry` | &lt;none&gt; | Private Docker registry to install ICP from. It should contain the appropriate ICP images |
+| `registry_username` | &lt;none&gt; | Private Docker registry username |
+| `registry_password` | &lt;none&gt; | Private Docker registry password |
 | `instance_name` | `icptest` | Name of the ICP installation. Will be used as basename for VMs. MUST consist of only lower case alphanumeric characters and '-' |
 | `domain` | `<instance_name>.icp` | Specify domain name to be used for linux customization on the VMs. |
 
@@ -224,5 +256,4 @@ The ICP configuration can further be customized by editing the [icp-config.yaml]
 | `audit_mount_type` | no | Type of mountpoint for the audit shared storage directory.  `nfs` by default. |
 | `audit_mount_options` | no | Mount options to pass to the audit mountpoint.  `defaults` by default. |
 | `icppassword` | yes | Password for the initial admin user in ICP. `admin` by default |
-| `disable_istio` | no | Disable Istio installation. `false` by default |
-| `disable_custom_metrics_adapter` | no | Disable custom metrics adapter installation. `false` by default |
+| `disable_management_services` | no | List of management services to disable. Default: `["istio", "vulnerability-advisor", "storage-glusterfs", "storage-minio"]` |

--- a/icp-config.yaml
+++ b/icp-config.yaml
@@ -1,10 +1,5 @@
 #kubelet_extra_args:
 kibana_install: true
-management_services:
- vulnerability-advisor: disabled
- istio: disabled
- storage-glusterfs: disabled
- storage-minio: disabled
 image-security-enforcement:
   clusterImagePolicy:
     - name: "docker.io/ibmcom/*"

--- a/icp-config.yaml
+++ b/icp-config.yaml
@@ -1,6 +1,7 @@
 #kubelet_extra_args:
 kibana_install: true
 management_services:
+ vulnerability-advisor: disabled
  istio: disabled
  storage-glusterfs: disabled
  storage-minio: disabled
@@ -8,6 +9,3 @@ image-security-enforcement:
   clusterImagePolicy:
     - name: "docker.io/ibmcom/*"
       policy:
-docker_extra_args:
-  - --storage-driver=devicemapper
-  - --storage-opt dm.directlvm_device=/dev/sdb

--- a/icp-deploy.tf
+++ b/icp-deploy.tf
@@ -6,6 +6,10 @@ locals {
     icp_priv_key   = "${tls_private_key.ssh.private_key_pem}"
     ssh_user       = "${var.ssh_user}"
     ssh_key_base64 = "${base64encode(tls_private_key.ssh.private_key_pem)}"
+
+    # This is just to have a long list of disabled items to use in icp-deploy.tf
+    disabled_list = "${list("disabled","disabled","disabled","disabled","disabled","disabled","disabled","disabled","disabled","disabled","disabled","disabled","disabled","disabled","disabled","disabled","disabled","disabled","disabled","disabled")}"
+    disabled_management_services = "${zipmap(var.disabled_management_services, slice(local.disabled_list, 0, length(var.disabled_management_services)))}"
 }
 
 ##################################
@@ -57,7 +61,8 @@ module "icpprovision" {
       "cluster_name"                    = "${var.instance_name}-cluster"
       "calico_ip_autodetection_method"  = "first-found"
       "default_admin_password"          = "${var.icppassword}"
-      "disabled_management_services"    = [ "${var.va["nodes"] == 0 ? "vulnerability-advisor" : "" }" , "${var.disable_istio == "true" ? "istio" : "" }", "${var.disable_custom_metrics_adapter == "true" ? "custom-metrics-adapter" : "" }" ]
+      # This is the list of disabled management services
+      "management_services"             = "${local.disabled_management_services}"
       #"image_repo"                      = "${dirname(local.image)}"
       #"private_registry_enabled"        = "${local.registry_creds != "" ? "true" : "false" }"
       #"private_registry_server"         = "${local.registry_creds != "" ? "${dirname(dirname(local.image))}" : "" }"

--- a/icp-deploy.tf
+++ b/icp-deploy.tf
@@ -1,7 +1,5 @@
 locals {
-#    registry_split = "${split("@", var.icp_inception_image)}"
-#    registry_creds = "${length(local.registry_split) > 1 ? "${element(local.registry_split, 0)}" : ""}"
-#    image          = "${length(local.registry_split) > 1 ? "${replace(var.icp_inception_image, "/.*@/", "")}" : "${var.icp_inception_image}" }"
+    image          = "${length(var.private_registry) > 1 ? "${var.private_registry}/${var.icp_inception_image}" : "${var.icp_inception_image}"}"
     icp_pub_key    = "${tls_private_key.ssh.public_key_openssh}"
     icp_priv_key   = "${tls_private_key.ssh.private_key_pem}"
     ssh_user       = "${var.ssh_user}"
@@ -29,7 +27,7 @@ module "icpprovision" {
     }
 
     # Provide desired ICP version to provision
-    icp-version = "${var.icp_inception_image}"
+    icp-version = "${length(var.registry_username) > 1 ?  "${var.registry_username}:${var.registry_password}@${local.image}" : "${local.image}"}"
     image_location = "${var.image_location}"
 
     parallell-image-pull = "${var.parallel_image_pull}"
@@ -63,11 +61,11 @@ module "icpprovision" {
       "default_admin_password"          = "${var.icppassword}"
       # This is the list of disabled management services
       "management_services"             = "${local.disabled_management_services}"
-      #"image_repo"                      = "${dirname(local.image)}"
-      #"private_registry_enabled"        = "${local.registry_creds != "" ? "true" : "false" }"
-      #"private_registry_server"         = "${local.registry_creds != "" ? "${dirname(dirname(local.image))}" : "" }"
-      #"docker_username"                 = "${local.registry_creds != "" ? "${replace(local.registry_creds, "/:.*/", "")}" : "" }"
-      #"docker_password"                 = "${local.registry_creds != "" ? "${replace(local.registry_creds, "/.*:/", "")}" : "" }"
+      "private_registry_enabled"        = "${length(var.private_registry) > 1 ? "true" : "false"}"
+      "private_registry_server"         = "${var.private_registry}"
+      "image_repo"                      = "${length(var.private_registry) > 1 ? "${dirname(local.image)}" : ""}"
+      "docker_username"                 = "${length(var.registry_username) > 1 ? "${var.registry_username}" : "'null'"}"
+      "docker_password"                 = "${length(var.registry_password) > 1 ? "${var.registry_password}" : "'null'"}"
     }
 
     # We will let terraform generate a new ssh keypair

--- a/scripts/add-private-ssh-key.sh
+++ b/scripts/add-private-ssh-key.sh
@@ -5,7 +5,7 @@ private_key_file=$HOME/.ssh/id_rsa
 
 if [ "$user_private_key" != "None" ] ; then
   if [ ! -f ${HOME}/.ssh/id_rsa ]; then
-    mkdir ~/.ssh
+    mkdir -p ~/.ssh
     chmod 700 ~/.ssh
     touch ${HOME}/.ssh/id_rsa
   fi

--- a/scripts/add-private-ssh-key.sh
+++ b/scripts/add-private-ssh-key.sh
@@ -4,16 +4,21 @@ user=$2
 private_key_file=$HOME/.ssh/id_rsa
 
 if [ "$user_private_key" != "None" ] ; then
-    echo "$user_private_key" > $private_key_file
-    chmod 400 $private_key_file
+  if [ ! -f ${HOME}/.ssh/id_rsa ]; then
+    mkdir ~/.ssh
+    chmod 700 ~/.ssh
+    touch ${HOME}/.ssh/id_rsa
+  fi
+  echo "$user_private_key" > $private_key_file
+  chmod 400 $private_key_file
 
-    eval "$(ssh-agent)"
-    ssh-add $private_key_file
+  eval "$(ssh-agent)"
+  ssh-add $private_key_file
 
-    if [[ $? -ne 0 ]]; then
-    	echo "FAILED to add private ssh key"
-    	exit 1
-    else
-    	echo "SUCCESFULLY added private ssh key"
+  if [[ $? -ne 0 ]]; then
+    echo "FAILED to add private ssh key"
+    exit 1
+  else
+    echo "SUCCESFULLY added private ssh key"
 	fi
 fi

--- a/scripts/add-public-ssh-key.sh
+++ b/scripts/add-public-ssh-key.sh
@@ -2,7 +2,7 @@
 user_public_key=$1
 if [ "$user_public_key" != "None" ] ; then
   if [ ! -f ${HOME}/.ssh/authorized_keys ]; then
-    mkdir ~/.ssh
+    mkdir -p ~/.ssh
     chmod 700 ~/.ssh
     touch ${HOME}/.ssh/authorized_keys
   fi

--- a/scripts/add-public-ssh-key.sh
+++ b/scripts/add-public-ssh-key.sh
@@ -1,12 +1,17 @@
 #!/bin/bash
 user_public_key=$1
 if [ "$user_public_key" != "None" ] ; then
-    echo "$user_public_key" >> $HOME/.ssh/authorized_keys
+  if [ ! -f ${HOME}/.ssh/authorized_keys ]; then
+    mkdir ~/.ssh
+    chmod 700 ~/.ssh
+    touch ${HOME}/.ssh/authorized_keys
+  fi
+  echo "$user_public_key" >> $HOME/.ssh/authorized_keys
 
-    if [[ $? -ne 0 ]]; then
-    	echo "FAILED to add public ssh key"
-    	exit 1
-    else
-    	echo "SUCCESFULLY added public ssh key"
+  if [[ $? -ne 0 ]]; then
+    echo "FAILED to add public ssh key"
+    exit 1
+  else
+    echo "SUCCESFULLY added public ssh key"
 	fi
 fi

--- a/scripts/create-part.sh
+++ b/scripts/create-part.sh
@@ -38,11 +38,20 @@ echo "Path to mount: ${path}"
 echo "Device is ${device}"
 
 sudo mkdir -p ${path}
-sudo parted -s -a optimal ${device} mklabel gpt -- mkpart primary ext4 1 -1
+sudo parted -s -a optimal ${device} mklabel gpt -- mkpart primary ext4 1 -1 && sleep 10
 
-sudo partprobe
+if [ $? != 0 ]; then
+  echo "Parted for ${device} failed. Please review the log file."
+fi
 
-sudo mkfs.ext4 ${device}1
+sudo partprobe && sleep 5
+
+sudo mkfs.ext4 ${device}1 && sleep 10
+
+if [ $? != 0 ]; then
+  echo "mkfs.ext4 for ${device}1 failed. Please review the log file."
+fi
+
 echo "${device}1 ${path}   ext4  defaults   0 0" | sudo tee -a /etc/fstab
 
 if [[ "${OSLEVEL}" == "ubuntu" ]]

--- a/variables.tf
+++ b/variables.tf
@@ -278,7 +278,7 @@ variable "ssh_keyfile" {
 
 variable "icp_inception_image" {
   description = "ICP image to use for installation"
-  default     = "ibmcom/icp-inception:2.1.0.3-ee"
+  default     = "ibmcom/icp-inception-amd64:3.1.0-ee"
 }
 
 variable "network_cidr" {

--- a/variables.tf
+++ b/variables.tf
@@ -217,13 +217,28 @@ variable "va" {
 
 
 variable "docker_package_location" {
-  description = "URI for docker package location, e.g. http://<myhost>/icp-docker-17.09_x86_64.bin or nfs:<myhost>/icp-docker-17.09_x86_64.bin"
+  description = "URI for docker package location, e.g. http://<myhost>/icp-docker-18.03_x86_64.bin or nfs:<myhost>/icp-docker-18.03_x86_64.bin"
   default     = ""
 }
 
 variable "image_location" {
-  description = "URI for image package location, e.g. http://<myhost>/ibm-cloud-private-x86_64-2.1.0.3.tar.gz or nfs:<myhost>/ibm-cloud-private-x86_64-2.1.0.3.tar.gz"
+  description = "URI for image package location, e.g. http://<myhost>/ibm-cloud-private-x86_64-3.1.0.tar.gz or nfs:<myhost>/ibm-cloud-private-x86_64-3.1.0.tar.gz"
   default     = ""
+}
+
+variable "private_registry" {
+  description = "Private docker registry where the ICP installation image is located"
+  default     = ""
+}
+
+variable "registry_username" {
+  description = "Username for the private docker restistry the ICP image will be grabbed from"
+  default   = ""
+}
+
+variable "registry_password" {
+  description = "Password for the private docker restistry the ICP image will be grabbed from"
+  default   = ""
 }
 
 variable "registry_mount_src" {

--- a/variables.tf
+++ b/variables.tf
@@ -291,17 +291,15 @@ variable "service_network_cidr" {
   default     = "10.10.10.0/24"
 }
 
-variable "disable_istio" {
-  description = "Disable Istio"
-  default     = "false"
-}
-
-variable "disable_custom_metrics_adapter" {
-  description = "Disable Custom Metrics Adapter"
-  default     = "false"
-}
-
 variable "parallel_image_pull" {
   description = "Parallel Image Pull"
   default     = "false"
+}
+
+# The following services can be disabled for 3.1
+# custom-metrics-adapter, image-security-enforcement, istio, metering, monitoring, service-catalog, storage-minio, storage-glusterfs, and vulnerability-advisor
+variable "disabled_management_services" {
+  description = "List of management services to disable"
+  type        = "list"
+  default     = ["istio", "vulnerability-advisor", "storage-glusterfs", "storage-minio"]
 }


### PR DESCRIPTION
Main points in this PR:

1. Refactor the ICP installation method (also added new section in README to explain this) to be able to install from NFS and private registry (with or without credentials)
2. Install docker from Ubuntu/RHEL repos if docker_package_location isnt specified (we now expect templates without docker installed.
3. partition /dev/sdb to be used by docker (Initial problem that triggered the new template creation)
4. New disable management services strategy where a list with the management services to be disabled is declared.

The template I created for testing terraform VMware is called **ubu_1604_31** and can be found on the `Templates` folder within the vSphere.